### PR TITLE
build(deps): batch the routine Dependabot bumps

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -38,7 +38,7 @@
       "rollForward": false
     },
     "meziantou.framework.nugetpackagevalidation.tool": {
-      "version": "2.0.3",
+      "version": "2.0.5",
       "commands": [
         "meziantou.validate-nuget-package"
       ],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
         if-no-files-found: error
 
     - name: Generate SBOM
-      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
       if: runner.os == 'Windows'
       with:
         artifact-name: fences.spdx.json

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -35,13 +35,13 @@ jobs:
         show-progress: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         build-mode: none
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         category: '/language:${{ matrix.language }}'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
         args: -color
 
     - name: Lint workflows with zizmor
-      uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+      uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
       with:
         persona: pedantic
 

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -42,6 +42,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Applies the same version bumps as the four low-risk, CI-green Dependabot PRs, batched onto one branch:

- github/codeql-action 4.37.8 → 4.37.9 (#15)
- zizmorcore/zizmor-action 0.6.2 → 0.6.3 (#16)
- anchore/sbom-action 0.24.0 → 0.24.2 (#17)
- meziantou.framework.nugetpackagevalidation.tool 2.0.3 → 2.0.5 (#18)

`coverlet.msbuild` (#6) is intentionally excluded — it's a 4-major-version jump in the coverage tool that overlaps with the in-progress `bugfix/14-coverage-collection-unreliable` work, so it's being handled separately.

Merging this closes #15, #16, #17, #18 (Dependabot auto-closes superseded PRs once the same version lands on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9qbDPaAnc9xjpBgrux8oR